### PR TITLE
Prevent animated background RAF leak on unmount

### DIFF
--- a/app/components/animated-background.tsx
+++ b/app/components/animated-background.tsx
@@ -55,6 +55,8 @@ export default function AnimatedBackground() {
 
     window.addEventListener("mousemove", handleMouseMove);
 
+    let frameId: number | null = null;
+
     const animate = () => {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
 
@@ -111,14 +113,20 @@ export default function AnimatedBackground() {
         });
       });
 
-      requestAnimationFrame(animate);
+      frameId = requestAnimationFrame(animate);
     };
 
-    animate();
+    frameId = requestAnimationFrame(animate);
 
     return () => {
       window.removeEventListener("resize", resizeCanvas);
       window.removeEventListener("mousemove", handleMouseMove);
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+      }
+      particles.length = 0;
+      mouseX = 0;
+      mouseY = 0;
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- track the requestAnimationFrame handle for the animated background and cancel it during cleanup to stop the loop
- reset particle and mouse state on teardown so a fresh animation starts after remounting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6b2261e34833293cd3e24c87de212