### PR TITLE
Scope cursor hiding to custom cursor activation

### DIFF
--- a/app/components/custom-cursor.tsx
+++ b/app/components/custom-cursor.tsx
@@ -73,6 +73,19 @@ export default function CustomCursor() {
     return () => window.cancelAnimationFrame(frame);
   }, []);
 
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isVisible) {
+      root.classList.add("cursor-hidden");
+    } else {
+      root.classList.remove("cursor-hidden");
+    }
+
+    return () => {
+      root.classList.remove("cursor-hidden");
+    };
+  }, [isVisible]);
+
   if (!isVisible) return null;
 
   return (

--- a/app/globals.css
+++ b/app/globals.css
@@ -33,17 +33,16 @@
   }
   body {
     @apply bg-background text-foreground;
-    cursor: none;
   }
 }
 
 html {
   scroll-behavior: smooth;
-  cursor: none;
 }
 
-/* Hide default cursor */
-* {
+/* Hide default cursor when custom cursor is active */
+.cursor-hidden,
+.cursor-hidden * {
   cursor: none !important;
 }
 


### PR DESCRIPTION
## Summary
- stop hiding the system cursor globally in CSS
- toggle a cursor-hidden class from the custom cursor component to hide the pointer only when active
- ensure the native cursor remains visible when the custom cursor is not running

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6b2a8a1648332b9dbff71397bf8be