### PR TITLE
Add About link to mobile navigation menu

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -282,7 +282,10 @@ export default function Portfolio() {
 
           <div className="flex items-center justify-between rounded-full border border-slate-800/70 bg-gray-950/90 px-4 py-2 shadow-md md:hidden">
             <span className="text-lg font-semibold text-blue-200">JW</span>
-            <div className="flex items-center gap-4 text-sm text-slate-200">
+            <div className="flex items-center gap-3 text-sm text-slate-200">
+              <a href="#about" className="cursor-hover">
+                About
+              </a>
               <a href="#projects" className="cursor-hover">
                 Work
               </a>


### PR DESCRIPTION
## Summary
- add an About link to the mobile navigation menu so it matches the desktop options
- slightly tighten spacing between mobile navigation items to keep the layout within the pill container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89d5b762c8332916cd9b050bb39c3