### PR TITLE
Create standalone skills section with animated marquee

### DIFF
--- a/app/components/skill-ticker.tsx
+++ b/app/components/skill-ticker.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useMemo } from "react";
+
+export type SkillTickerItem = {
+  name: string;
+  short: string;
+  color: string;
+  emphasis?: string;
+};
+
+type SkillTickerProps = {
+  skills: SkillTickerItem[];
+};
+
+export default function SkillTicker({ skills }: SkillTickerProps) {
+  const loopedSkills = useMemo(() => [...skills, ...skills], [skills]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between text-xs text-slate-300/80">
+        <div className="flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-4 py-1.5 uppercase tracking-[0.4em] text-blue-200">
+          Marquee
+        </div>
+        <span className="hidden md:inline-flex items-center gap-2 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-[0.7rem] font-medium text-emerald-200/90">
+          Auto-scroll enabled
+        </span>
+      </div>
+
+      <div className="relative overflow-hidden rounded-3xl border border-blue-500/20 bg-gray-950/80 p-4 shadow-[0_20px_50px_-45px_rgba(59,130,246,0.9)]">
+        <div className="pointer-events-none absolute inset-y-0 left-0 w-32 bg-gradient-to-r from-gray-950 via-gray-950/95 to-transparent" />
+        <div className="pointer-events-none absolute inset-y-0 right-0 w-32 bg-gradient-to-l from-gray-950 via-gray-950/95 to-transparent" />
+
+        <div className="flex min-w-max items-center gap-5 animate-[skill-marquee_24s_linear_infinite]">
+          {loopedSkills.map((skill, index) => (
+            <div
+              key={`${skill.name}-${index}`}
+              className="group flex min-w-[190px] items-center gap-4 rounded-2xl border border-blue-500/20 bg-gradient-to-br from-slate-900/80 via-slate-900/50 to-slate-900/30 px-5 py-3 shadow-[0_12px_30px_-24px_rgba(59,130,246,0.85)] transition hover:border-blue-400/60"
+            >
+              <div
+                className="flex h-12 w-12 items-center justify-center rounded-xl text-base font-semibold text-white shadow-inner"
+                style={{ backgroundColor: skill.color }}
+              >
+                {skill.short}
+              </div>
+              <div className="flex flex-col">
+                <span className="text-sm font-semibold text-slate-100">{skill.name}</span>
+                {skill.emphasis && (
+                  <span className="text-xs text-slate-400">{skill.emphasis}</span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,6 @@ import {
   ExternalLink,
   ArrowRight,
   Brain,
-  Cpu,
   Award,
   BookOpen,
   Code,
@@ -29,6 +28,7 @@ import CustomCursor from "./components/custom-cursor";
 import HeroScene from "./components/hero-scene";
 import { BlurRevealText } from "./components/blur-reveal-text";
 import SkillSlider, { type SkillSlide } from "./components/skill-slider";
+import SkillTicker, { type SkillTickerItem } from "./components/skill-ticker";
 import Image from "next/image";
 
 export default function Portfolio() {
@@ -192,6 +192,81 @@ export default function Portfolio() {
     "Java",
   ];
 
+  const marqueeSkills: SkillTickerItem[] = [
+    {
+      name: "Python",
+      short: "Py",
+      color: "#3776AB",
+      emphasis: "AI pipelines",
+    },
+    {
+      name: "TypeScript",
+      short: "TS",
+      color: "#3178C6",
+      emphasis: "typed React",
+    },
+    {
+      name: "JavaScript",
+      short: "JS",
+      color: "#F7DF1E",
+      emphasis: "frontend UX",
+    },
+    {
+      name: "Next.js",
+      short: "Nx",
+      color: "#000000",
+      emphasis: "full-stack",
+    },
+    {
+      name: "TensorFlow",
+      short: "TF",
+      color: "#FF6F00",
+      emphasis: "deep learning",
+    },
+    {
+      name: "PyTorch",
+      short: "PT",
+      color: "#EE4C2C",
+      emphasis: "model ops",
+    },
+    {
+      name: "Supabase",
+      short: "SB",
+      color: "#3ECF8E",
+      emphasis: "backend",
+    },
+    {
+      name: "Git",
+      short: "Gt",
+      color: "#F05032",
+      emphasis: "collaboration",
+    },
+    {
+      name: "Figma",
+      short: "Fg",
+      color: "#F24E1E",
+      emphasis: "design systems",
+    },
+    {
+      name: "HTML",
+      short: "H5",
+      color: "#E34F26",
+      emphasis: "semantics",
+    },
+    {
+      name: "CSS",
+      short: "CS",
+      color: "#1572B6",
+      emphasis: "responsive UI",
+    },
+    {
+      name: "Java",
+      short: "Jv",
+      color: "#5382A1",
+      emphasis: "OOP",
+    },
+  ];
+
   const softSkills = [
     "Problem-Solving & Analytical Thinking",
     "Adaptability & Continuous Learning",
@@ -259,6 +334,12 @@ export default function Portfolio() {
                     About
                   </a>
                   <a
+                    href="#skills"
+                    className="cursor-hover rounded-full px-3 py-1 transition hover:bg-sky-500/20 hover:text-sky-100"
+                  >
+                    Skills
+                  </a>
+                  <a
                     href="#projects"
                     className="cursor-hover rounded-full px-3 py-1 transition hover:bg-sky-500/20 hover:text-sky-100"
                   >
@@ -287,6 +368,9 @@ export default function Portfolio() {
             <div className="flex items-center gap-3 text-sm text-slate-200">
               <a href="#about" className="cursor-hover">
                 About
+              </a>
+              <a href="#skills" className="cursor-hover">
+                Skills
               </a>
               <a href="#projects" className="cursor-hover">
                 Work
@@ -365,6 +449,46 @@ export default function Portfolio() {
                 <FileText className="w-4 h-4" />
               </a>
             </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* Skills Section */}
+      <section id="skills" className="relative px-4 py-20 sm:px-6 lg:px-8">
+        <div className="mx-auto flex max-w-6xl flex-col gap-12">
+          <div className="mx-auto max-w-3xl text-center">
+            <span className="mb-4 inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-4 py-1 text-xs font-medium uppercase tracking-[0.4em] text-blue-300">
+              Skills
+            </span>
+            <h2 className="text-4xl font-bold text-blue-100 sm:text-5xl">
+              Hard Skills in Motion
+            </h2>
+            <p className="mt-4 text-base leading-relaxed text-gray-400">
+              A dedicated lane for the technologies I work with daily&mdash;streamlined into a single, flowing row.
+            </p>
+          </div>
+
+          <SkillTicker skills={marqueeSkills} />
+
+          <div className="rounded-3xl border border-blue-500/20 bg-gray-900/70 p-6 shadow-[0_25px_80px_-60px_rgba(59,130,246,0.8)]">
+            <SkillSlider slides={hardSkillSlides} />
+          </div>
+
+          <div className="rounded-3xl border border-gray-800 bg-gray-900/70 p-6 shadow-lg">
+            <h4 className="mb-4 text-sm font-semibold uppercase tracking-[0.4em] text-blue-400/80">
+              Quick View
+            </h4>
+            <div className="flex flex-wrap gap-2">
+              {quickSkills.map((skill) => (
+                <Badge
+                  key={skill}
+                  variant="secondary"
+                  className="bg-gray-800/80 text-gray-200 transition hover:bg-blue-500/80 cursor-hover"
+                >
+                  {skill}
+                </Badge>
+              ))}
+            </div>
           </div>
         </div>
       </section>
@@ -465,33 +589,6 @@ export default function Portfolio() {
                   <p>
                     I thrive in open, collaborative team environments where diverse perspectives are encouraged, fostering brainstorming that leads to innovative solutions and optimal outcomes. I view challenges as invaluable opportunities for personal and professional growth.
                   </p>
-                </div>
-              </div>
-
-              <div className="grid gap-6 lg:grid-cols-1">
-                <div className="rounded-xl border border-gray-800 bg-gray-900/80 p-6 shadow-lg">
-                  <h3 className="mb-4 flex items-center gap-2 text-xl font-semibold text-blue-300">
-                    <Cpu className="w-5 h-5" />
-                    Technical Skills
-                  </h3>
-                  <SkillSlider slides={hardSkillSlides} />
-                </div>
-
-                <div className="rounded-xl border border-gray-800 bg-gray-900/70 p-6 shadow-lg">
-                  <h4 className="mb-4 text-sm font-semibold uppercase tracking-[0.4em] text-blue-400/80">
-                    Quick View
-                  </h4>
-                  <div className="flex flex-wrap gap-2">
-                    {quickSkills.map((skill) => (
-                      <Badge
-                        key={skill}
-                        variant="secondary"
-                        className="bg-gray-800/80 text-gray-200 transition hover:bg-blue-500/80 cursor-hover"
-                      >
-                        {skill}
-                      </Badge>
-                    ))}
-                  </div>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- add a dedicated skills section between the hero and about blocks
- implement a marquee-style hard skills ticker and reuse the detailed slider outside the about section
- update navigation anchors and relocate the quick view badges into the new skills area

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8a6e5c184833280ceb0c1ee293faf