### PR TITLE
Add scroll-triggered floating headline animation

### DIFF
--- a/app/components/scroll-float.module.css
+++ b/app/components/scroll-float.module.css
@@ -1,0 +1,17 @@
+.scrollFloat {
+  overflow: hidden;
+}
+
+.scrollFloatText {
+  display: inline-block;
+  font-size: clamp(1.6rem, 8vw, 10rem);
+  font-weight: 900;
+  text-align: center;
+  line-height: 1.5;
+  color: inherit;
+}
+
+.char {
+  display: inline-block;
+  will-change: opacity, transform;
+}

--- a/app/components/scroll-float.tsx
+++ b/app/components/scroll-float.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import {
+  Children,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+
+import { cn } from "@/lib/utils";
+
+import styles from "./scroll-float.module.css";
+
+gsap.registerPlugin(ScrollTrigger);
+
+export interface ScrollFloatProps {
+  children: ReactNode;
+  scrollContainerRef?: RefObject<HTMLElement>;
+  containerClassName?: string;
+  textClassName?: string;
+  animationDuration?: number;
+  ease?: string;
+  scrollStart?: string;
+  scrollEnd?: string;
+  stagger?: number;
+}
+
+const charClassName = styles.char;
+
+const ScrollFloat: React.FC<ScrollFloatProps> = ({
+  children,
+  scrollContainerRef,
+  containerClassName,
+  textClassName,
+  animationDuration = 1,
+  ease = "back.inOut(2)",
+  scrollStart = "center bottom+=50%",
+  scrollEnd = "bottom bottom-=40%",
+  stagger = 0.03,
+}) => {
+  const containerRef = useRef<HTMLHeadingElement>(null);
+
+  const content = useMemo(() => {
+    if (typeof children === "string") {
+      return children;
+    }
+
+    return Children.toArray(children)
+      .map((child) => {
+        if (typeof child === "string" || typeof child === "number") {
+          return String(child);
+        }
+
+        return "";
+      })
+      .join("");
+  }, [children]);
+
+  const characters = useMemo(
+    () =>
+      content.split("").map((char, index) => (
+        <span className={styles.char} key={index}>
+          {char === " " ? "\u00A0" : char}
+        </span>
+      )),
+    [content]
+  );
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const ctx = gsap.context(() => {
+      const charElements = Array.from(
+        el.getElementsByClassName(charClassName)
+      );
+
+      if (!charElements.length) return;
+
+      const animation = gsap.fromTo(
+        charElements,
+        {
+          opacity: 0,
+          yPercent: 120,
+          scaleY: 2.3,
+          scaleX: 0.7,
+          transformOrigin: "50% 0%",
+        },
+        {
+          duration: animationDuration,
+          ease,
+          opacity: 1,
+          yPercent: 0,
+          scaleY: 1,
+          scaleX: 1,
+          stagger,
+          scrollTrigger: {
+            trigger: el,
+            start: scrollStart,
+            end: scrollEnd,
+            scrub: true,
+            ...(scrollContainerRef?.current
+              ? { scroller: scrollContainerRef.current }
+              : {}),
+          },
+        }
+      );
+
+      return () => {
+        animation.scrollTrigger?.kill();
+        animation.kill();
+      };
+    }, el);
+
+    return () => {
+      ctx.revert();
+    };
+  }, [
+    animationDuration,
+    ease,
+    scrollContainerRef,
+    scrollEnd,
+    scrollStart,
+    stagger,
+    content,
+  ]);
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <h2
+      ref={containerRef}
+      className={cn(styles.scrollFloat, containerClassName)}
+    >
+      <span className={cn(styles.scrollFloatText, textClassName)}>
+        {characters}
+      </span>
+    </h2>
+  );
+};
+
+export default ScrollFloat;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,6 +27,7 @@ import AnimatedBackground from "./components/animated-background";
 import CustomCursor from "./components/custom-cursor";
 import HeroScene from "./components/hero-scene";
 import { BlurRevealText } from "./components/blur-reveal-text";
+import ScrollFloat from "./components/scroll-float";
 import SkillSlider, { type SkillSlide } from "./components/skill-slider";
 import SkillTicker, { type SkillTickerItem } from "./components/skill-ticker";
 import Image from "next/image";
@@ -451,6 +452,23 @@ export default function Portfolio() {
             </Button>
           </div>
         </div>
+      </section>
+
+      <section
+        aria-label="Floating headline"
+        className="relative px-4 py-16 sm:px-6 lg:px-8"
+      >
+        <ScrollFloat
+          containerClassName="mx-auto max-w-5xl text-center"
+          textClassName="bg-gradient-to-r from-sky-300 via-purple-300 to-cyan-300 bg-clip-text text-transparent drop-shadow-[0_0_25px_rgba(56,189,248,0.25)]"
+          animationDuration={1}
+          ease="back.inOut(2)"
+          scrollStart="top bottom"
+          scrollEnd="bottom center"
+          stagger={0.035}
+        >
+          Crafting Intelligent Experiences with Code &amp; Curiosity
+        </ScrollFloat>
       </section>
 
       {/* About Section */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-three/fiber": "^9.3.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "gsap": "^3.13.0",
         "lucide-react": "^0.517.0",
         "next": "15.3.3",
         "react": "^19.0.0",
@@ -3887,6 +3888,12 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gsap": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
+      "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-three/fiber": "^9.3.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "gsap": "^3.13.0",
     "lucide-react": "^0.517.0",
     "next": "15.3.3",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary
- add a reusable ScrollFloat component powered by GSAP scroll triggers
- introduce a floating headline section that animates the portfolio tagline while scrolling
- include the GSAP dependency for scroll-based text animation support

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9fbceef04833293b791691e9efa9b