### PR TITLE
Add scroll reveal hook with staggered child animation delays

### DIFF
--- a/app/components/use-scroll-reveal.ts
+++ b/app/components/use-scroll-reveal.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type ScrollRevealOptions = {
+  threshold?: number;
+  rootMargin?: string;
+  once?: boolean;
+};
+
+type ScrollRevealState = {
+  ref: (node: HTMLElement | null) => void;
+  isRevealed: boolean;
+  prefersReducedMotion: boolean;
+};
+
+export function useScrollReveal(
+  { threshold = 0.2, rootMargin = "0px", once = true }: ScrollRevealOptions = {}
+): ScrollRevealState {
+  const [element, setElement] = useState<HTMLElement | null>(null);
+  const [isRevealed, setIsRevealed] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+      if (event.matches) {
+        setIsRevealed(true);
+      } else if (!once && !event.matches) {
+        setIsRevealed(false);
+      }
+    };
+
+    setPrefersReducedMotion(mediaQuery.matches);
+    if (mediaQuery.matches) {
+      setIsRevealed(true);
+    }
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, [once]);
+
+  useEffect(() => {
+    if (!element || prefersReducedMotion) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setIsRevealed(true);
+            if (once) {
+              observer.disconnect();
+            }
+          } else if (!once) {
+            setIsRevealed(false);
+          }
+        });
+      },
+      { threshold, rootMargin }
+    );
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [element, prefersReducedMotion, threshold, rootMargin, once]);
+
+  const ref = useCallback((node: HTMLElement | null) => {
+    setElement(node);
+    if (node && prefersReducedMotion) {
+      setIsRevealed(true);
+    }
+  }, [prefersReducedMotion]);
+
+  return useMemo(
+    () => ({
+      ref,
+      isRevealed,
+      prefersReducedMotion,
+    }),
+    [ref, isRevealed, prefersReducedMotion]
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,9 +43,15 @@ import HeroScene from "./components/hero-scene";
 import { BlurRevealText } from "./components/blur-reveal-text";
 import SkillSlider, { type SkillSlide } from "./components/skill-slider";
 import SkillTicker, { type SkillTickerItem } from "./components/skill-ticker";
+import { useScrollReveal } from "./components/use-scroll-reveal";
+import { cn } from "@/lib/utils";
 import Image from "next/image";
 
 export default function Portfolio() {
+  const statsReveal = useScrollReveal();
+  const projectsReveal = useScrollReveal();
+  const contactReveal = useScrollReveal();
+
   const projects = [
     {
       title: "Jernih - AI-powered Water Quality Analysis Platform",
@@ -497,11 +503,24 @@ export default function Portfolio() {
           <div className="grid items-stretch gap-10 lg:grid-cols-[1.05fr_0.95fr] xl:gap-14">
             {/* Stats Section - Replacing the image */}
             <div className="space-y-6">
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div
+                ref={statsReveal.ref}
+                className="grid grid-cols-1 gap-4 sm:grid-cols-2"
+              >
                 {stats.map((stat, index) => (
                   <Card
                     key={index}
-                    className="bg-gray-900/80 border-gray-700 transition-all duration-300 hover:scale-[1.02] hover:border-blue-500 cursor-hover"
+                    className={cn(
+                      "bg-gray-900/80 border-gray-700 transition-all duration-300 hover:scale-[1.02] hover:border-blue-500 cursor-hover",
+                      statsReveal.isRevealed
+                        ? "opacity-100 translate-y-0"
+                        : "opacity-0 translate-y-4"
+                    )}
+                    style={
+                      statsReveal.isRevealed && !statsReveal.prefersReducedMotion
+                        ? { transitionDelay: `${index * 60}ms` }
+                        : undefined
+                    }
                   >
                     <CardContent className="p-6 text-center">
                       <stat.icon className="w-8 h-8 text-blue-400 mx-auto mb-3" />
@@ -658,11 +677,24 @@ export default function Portfolio() {
           <h2 className="text-4xl font-bold text-center mb-16 text-blue-400">
             Featured Projects
           </h2>
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+          <div
+            ref={projectsReveal.ref}
+            className="grid md:grid-cols-2 lg:grid-cols-3 gap-8"
+          >
             {projects.map((project, index) => (
               <Card
                 key={index}
-                className="flex h-full flex-col border-gray-700 bg-gray-900/80 pt-0 transition-all duration-300 hover:scale-[1.02] hover:border-blue-500 cursor-hover"
+                className={cn(
+                  "flex h-full flex-col border-gray-700 bg-gray-900/80 pt-0 transition-all duration-300 hover:scale-[1.02] hover:border-blue-500 cursor-hover",
+                  projectsReveal.isRevealed
+                    ? "opacity-100 translate-y-0"
+                    : "opacity-0 translate-y-4"
+                )}
+                style={
+                  projectsReveal.isRevealed && !projectsReveal.prefersReducedMotion
+                    ? { transitionDelay: `${index * 60}ms` }
+                    : undefined
+                }
               >
                 {/* <CardHeader className="p-0">
                   <div className="w-full h-48 bg-gradient-to-br from-blue-600/20 to-purple-600/20 rounded-t-lg flex items-center justify-center">
@@ -748,8 +780,11 @@ export default function Portfolio() {
             to reach out through any of the channels below!
           </p>
 
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-            {contactMethods.map((method) => {
+          <div
+            ref={contactReveal.ref}
+            className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4"
+          >
+            {contactMethods.map((method, index) => {
               const Icon = method.icon;
               const isExternal = method.href.startsWith("http");
 
@@ -761,7 +796,19 @@ export default function Portfolio() {
                   rel={isExternal ? "noopener noreferrer" : undefined}
                   className="group h-full"
                 >
-                  <Card className="h-full border-gray-700 bg-gray-900/80 transition-all group-hover:border-blue-500 group-hover:shadow-[0_0_25px_rgba(56,189,248,0.25)] cursor-hover">
+                  <Card
+                    className={cn(
+                      "h-full border-gray-700 bg-gray-900/80 transition-all group-hover:border-blue-500 group-hover:shadow-[0_0_25px_rgba(56,189,248,0.25)] cursor-hover",
+                      contactReveal.isRevealed
+                        ? "opacity-100 translate-y-0"
+                        : "opacity-0 translate-y-4"
+                    )}
+                    style={
+                      contactReveal.isRevealed && !contactReveal.prefersReducedMotion
+                        ? { transitionDelay: `${index * 60}ms` }
+                        : undefined
+                    }
+                  >
                     <CardContent className="flex h-full flex-col items-center gap-3 p-6 text-center">
                       <div className="flex h-12 w-12 items-center justify-center rounded-full border border-blue-500/40 bg-blue-500/10 text-blue-300 shadow-inner">
                         <Icon className="h-6 w-6" />


### PR DESCRIPTION
## Summary
- add a reusable `useScrollReveal` hook that tracks reveal state and respects the reduced motion media query
- stagger the stats, project, and contact cards with initial hidden classes that clear once their parent is revealed
- ensure animation delays are skipped when reduced motion is requested while preserving existing hover styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da1318926c8332a8e98c242f8b9f2e