### PR TITLE
Pause skill marquees until scrolled into view

### DIFF
--- a/app/components/skill-slider.tsx
+++ b/app/components/skill-slider.tsx
@@ -3,6 +3,7 @@
 import { type CSSProperties, useMemo, useState } from "react";
 import { ChevronLeft, ChevronRight, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useInView } from "@/lib/use-in-view";
 
 export type SkillSlide = {
   name: string;
@@ -17,6 +18,7 @@ type SkillSliderProps = {
 export default function SkillSlider({ slides }: SkillSliderProps) {
   const [direction, setDirection] = useState<"left" | "right">("left");
   const [isPaused, setIsPaused] = useState(false);
+  const { ref: inViewRef, isInView } = useInView<HTMLDivElement>();
 
   const marqueeSlides = useMemo(() => [...slides, ...slides], [slides]);
 
@@ -24,13 +26,13 @@ export default function SkillSlider({ slides }: SkillSliderProps) {
     () => ({
       animation: "skill-marquee 26s linear infinite",
       animationDirection: direction === "left" ? "normal" : "reverse",
-      animationPlayState: isPaused ? "paused" : "running",
+      animationPlayState: isPaused || !isInView ? "paused" : "running",
     }),
-    [direction, isPaused]
+    [direction, isPaused, isInView]
   );
 
   return (
-    <div className="space-y-5">
+    <div ref={inViewRef} className="space-y-5">
       <div className="flex items-center justify-between gap-3 text-sm text-blue-100">
         <div className="flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-4 py-1.5">
           <Sparkles className="h-4 w-4" />

--- a/app/components/skill-ticker.tsx
+++ b/app/components/skill-ticker.tsx
@@ -3,6 +3,7 @@
 import { type ComponentType, useMemo } from "react";
 
 import LogoLoop from "@/components/logo-loop";
+import { useInView } from "@/lib/use-in-view";
 
 export type SkillTickerItem = {
   name: string;
@@ -17,6 +18,7 @@ type SkillTickerProps = {
 };
 
 export default function SkillTicker({ skills }: SkillTickerProps) {
+  const { ref: inViewRef, isInView } = useInView<HTMLDivElement>();
   const logoItems = useMemo(
     () =>
       skills.map((skill) => {
@@ -51,7 +53,7 @@ export default function SkillTicker({ skills }: SkillTickerProps) {
   );
 
   return (
-    <div className="space-y-6">
+    <div ref={inViewRef} className="space-y-6">
       <div className="flex items-center justify-between text-xs text-slate-300/80">
         <div className="flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-4 py-1.5 uppercase tracking-[0.4em] text-blue-200">
           Marquee
@@ -64,7 +66,7 @@ export default function SkillTicker({ skills }: SkillTickerProps) {
       <div className="relative overflow-hidden rounded-3xl border border-blue-500/20 bg-gray-950/80 shadow-[0_20px_50px_-45px_rgba(59,130,246,0.9)]">
         <LogoLoop
           logos={logoItems}
-          speed={100}
+          speed={isInView ? 100 : 0}
           direction="left"
           logoHeight={72}
           gap={32}

--- a/lib/use-in-view.ts
+++ b/lib/use-in-view.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type UseInViewOptions = IntersectionObserverInit;
+
+type UseInViewResult<T extends Element> = {
+  ref: (node: T | null) => void;
+  isInView: boolean;
+  isIntersecting: boolean;
+  prefersReducedMotion: boolean;
+};
+
+function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    const handleChange = () => {
+      setPrefersReducedMotion(mediaQuery.matches);
+    };
+
+    handleChange();
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+export function useInView<T extends Element>(
+  options?: UseInViewOptions,
+): UseInViewResult<T> {
+  const [element, setElement] = useState<T | null>(null);
+  const [isIntersecting, setIsIntersecting] = useState(false);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  useEffect(() => {
+    const node = element;
+
+    if (!node || typeof window === "undefined") {
+      return undefined;
+    }
+
+    if (typeof IntersectionObserver === "undefined") {
+      setIsIntersecting(true);
+      return undefined;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      const [entry] = entries;
+      setIsIntersecting(Boolean(entry?.isIntersecting));
+    }, options);
+
+    observer.observe(node);
+
+    return () => {
+      observer.unobserve(node);
+      observer.disconnect();
+    };
+  }, [element, options]);
+
+  useEffect(() => {
+    if (!element) {
+      setIsIntersecting(false);
+    }
+  }, [element]);
+
+  const ref = useCallback((node: T | null) => {
+    setElement(node);
+  }, []);
+
+  const isInView = useMemo(
+    () => Boolean(isIntersecting && !prefersReducedMotion),
+    [isIntersecting, prefersReducedMotion],
+  );
+
+  return {
+    ref,
+    isInView,
+    isIntersecting,
+    prefersReducedMotion,
+  };
+}
+
+export type { UseInViewResult };


### PR DESCRIPTION
## Summary
- add a shared `useInView` hook that watches visibility and respects `prefers-reduced-motion`
- pause the SkillSlider marquee animation until the section enters the viewport
- freeze the SkillTicker logo loop until it is visible on screen

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da131a1b00833283d46ad5b0a6c6e2