### PR TITLE
Improve scroll reveal animation smoothness

### DIFF
--- a/app/components/scroll-reveal.tsx
+++ b/app/components/scroll-reveal.tsx
@@ -85,7 +85,7 @@ const ScrollReveal = forwardRef<HTMLElement, ScrollRevealProps>(
       <Component
         ref={setRefs}
         data-reveal={isRevealed ? "true" : "false"}
-        className={cn("will-change-transform", className)}
+        className={cn("will-change-[transform,opacity,filter]", className)}
         {...props}
       >
         {children}

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,10 @@
     --input: 217.2 32.6% 17.5%;
     --ring: 224.3 76.3% 94.1%;
     --radius: 0.5rem;
+    --reveal-duration: 650ms;
+    --reveal-ease: cubic-bezier(0.22, 1, 0.36, 1);
+    --reveal-distance: 28px;
+    --reveal-blur: 14px;
   }
 }
 
@@ -73,11 +77,19 @@ html.cursor-hidden * {
 }
 
 @layer utilities {
-  [data-reveal="false"] {
-    @apply opacity-0 translate-y-6;
+  [data-reveal] {
+    opacity: 0;
+    transform: translateY(var(--reveal-distance)) scale(0.98);
+    filter: blur(var(--reveal-blur));
+    transition-property: opacity, transform, filter;
+    transition-duration: var(--reveal-duration);
+    transition-timing-function: var(--reveal-ease);
+    transition-delay: var(--reveal-delay, 0s);
   }
 
   [data-reveal="true"] {
-    @apply opacity-100 translate-y-0 transition-opacity transition-transform duration-700 ease-out;
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    filter: blur(0);
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,15 +44,10 @@ import ScrollReveal from "./components/scroll-reveal";
 import { BlurRevealText } from "./components/blur-reveal-text";
 import SkillSlider, { type SkillSlide } from "./components/skill-slider";
 import SkillTicker, { type SkillTickerItem } from "./components/skill-ticker";
-import { useScrollReveal } from "./components/use-scroll-reveal";
 // import { cn } from "@/lib/utils";
 import Image from "next/image";
 
 export default function Portfolio() {
-  const statsReveal = useScrollReveal();
-  const projectsReveal = useScrollReveal();
-  const contactReveal = useScrollReveal();
-
   const projects = [
     {
       title: "Jernih - AI-powered Water Quality Analysis Platform",


### PR DESCRIPTION
## Summary
- refine the scroll reveal styles for a smoother fade-up effect with blur easing
- remove unused scroll reveal hook wiring from the portfolio page
- expand the scroll reveal component styling hints to cover opacity and filter changes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da196ef1848332baa22c23bc8f544d