### PR TITLE
Hide custom cursor dot over skill slider cards

### DIFF
--- a/app/components/custom-cursor.tsx
+++ b/app/components/custom-cursor.tsx
@@ -142,6 +142,8 @@ export default function CustomCursor() {
             className="absolute h-3 w-3 rounded-full bg-white shadow-[0_0_12px_rgba(255,255,255,0.6)]"
             style={{
               transform: `scale(${isHovering ? 0.9 : 1})`,
+              opacity: isHovering ? 0 : 1,
+              transition: "opacity 0.2s ease-out, transform 0.2s ease-out",
             }}
           />
           <div className="absolute h-16 w-16 rounded-full bg-sky-400/20 blur-2xl" />

--- a/app/components/skill-slider.tsx
+++ b/app/components/skill-slider.tsx
@@ -65,7 +65,7 @@ export default function SkillSlider({ slides }: SkillSliderProps) {
             {marqueeSlides.map((slide, index) => (
               <article
                 key={`${slide.name}-${index}`}
-                className="min-w-[240px] max-w-[280px] rounded-2xl border border-blue-500/20 bg-gradient-to-br from-slate-900/70 via-slate-900/40 to-slate-900/20 p-5 text-left text-slate-100 shadow-[0_10px_30px_-20px_rgba(59,130,246,0.45)] backdrop-blur-sm"
+                className="cursor-hover min-w-[240px] max-w-[280px] rounded-2xl border border-blue-500/20 bg-gradient-to-br from-slate-900/70 via-slate-900/40 to-slate-900/20 p-5 text-left text-slate-100 shadow-[0_10px_30px_-20px_rgba(59,130,246,0.45)] backdrop-blur-sm"
               >
                 <div className="flex flex-col gap-3">
                   <span className="text-[0.65rem] font-semibold uppercase tracking-[0.45em] text-blue-300/70">


### PR DESCRIPTION
## Summary
- add the `cursor-hover` class to each skill marquee card so the custom cursor treats them as hover targets
- fade out the custom cursor core when hovering interactive elements to eliminate the white dot

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68da1ac90bfc833293b577d16686218c