### PR TITLE
Fix marquee fade and wire CV download CTA

### DIFF
--- a/app/components/skill-ticker.tsx
+++ b/app/components/skill-ticker.tsx
@@ -73,7 +73,7 @@ export default function SkillTicker({ skills }: SkillTickerProps) {
           pauseOnHover
           scaleOnHover
           fadeOut
-          fadeOutColor="rgba(15, 23, 42, 0.95)"
+          fadeOutColor="rgba(2, 6, 23, 0.95)"
           ariaLabel="Technology partners"
           className="px-4 py-5"
         />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -468,7 +468,7 @@ export default function Portfolio() {
               size="lg"
               className="w-full bg-purple-600 text-white transition-all hover:scale-105 hover:bg-purple-700 cursor-hover sm:w-auto"
             >
-              <a href="" download className="flex items-center gap-2">
+              <a href="/JeremyWijaya_CV_ATS.pdf" download className="flex items-center gap-2">
                 Download CV
                 <FileText className="w-4 h-4" />
               </a>


### PR DESCRIPTION
## Summary
- darken the marquee fade overlay so the white edge artifact disappears against the ticker background
- link the hero Download CV button to the PDF stored in `public` to allow direct downloads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da248b103483329c4ae6a6f093defd